### PR TITLE
Support using custom urls (incl local files) as proto source

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "GRPC client for Tari wallet",
   "main": "./src/index.js",
   "scripts": {
-    "build": "npm run update-protos",
-    "update-protos": "node ./protos/update_protos.js",
+    "build": "npm run sync-protos",
+    "sync-protos": "node ./protos/sync-protos.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Tari development community",


### PR DESCRIPTION
Allow custom urls to be provided as a cli argument to `sync-protos.js`.
This is useful for updating proto files to unreleased code dring
development.