### PR TITLE
GRPC Update - Identify

### DIFF
--- a/protos/wallet.proto
+++ b/protos/wallet.proto
@@ -28,7 +28,10 @@ import "types.proto";
 
 // The gRPC interface for interacting with the wallet.
 service Wallet {
+    // This returns the current version
     rpc GetVersion (GetVersionRequest) returns (GetVersionResponse);
+    // This returns the identity information
+    rpc Identify (GetIdentityRequest) returns (GetIdentityResponse);
     // This returns a coinbase transaction
     rpc GetCoinbase (GetCoinbaseRequest) returns (GetCoinbaseResponse);
     // Send Tari to a number of recipients
@@ -38,6 +41,14 @@ service Wallet {
 }
 
 message GetVersionRequest { }
+
+message GetIdentityRequest { }
+
+message GetIdentityResponse {
+    bytes public_key = 1;
+    string public_address = 2;
+    bytes node_id = 3;
+}
 
 message GetVersionResponse {
     string version = 1;

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ function connect(address) {
 function Client(address) {
     this.inner = connect(address);
 
-    ['getVersion', 'getCoinbase', 'transfer', 'getTransactionInfo'].forEach((method) => {
+    ['getVersion', 'identify', 'getCoinbase', 'transfer', 'getTransactionInfo'].forEach((method) => {
         this[method] = (arg) => this.inner[method]().sendMessage(arg);
     })
 }


### PR DESCRIPTION
This PR adds Identify to the GRPC methods to be able to query out the public key and public address for the wallet as these fields now exist within the database instead of in a standalone file.

Impl is currently here: https://github.com/StriderDM/tari/commit/2214b1965da8b80d0f34e38dc6b37248b0ceadbd